### PR TITLE
Add a simple development server

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ entry points into applications. It's broadly similar to microframeworks like
 1. It's tiny. The redfox package contains under 100 lines of code. Redfox
     builds heavily on the [Werkzeug](http://werkzeug.pocoo.org) tools to implement
     its features, rather than re-reinventing the wheel.
-2. It's clean. The following is a valid Redfox application class:
+2. It's clean. The following is a valid Redfox application:
 
         from werkzeug import Response
         from redfox import WebApplication
@@ -19,6 +19,10 @@ entry points into applications. It's broadly similar to microframeworks like
             @get('/')
             def index(self, request):
                 return Response("Hello, world!")
+        
+        if __name__ == '__main__':
+            from redfox import server
+            server.run(Example())
 
 3. It's minimal. Redfox does not impose an ORM model, or a templating system.
 Bring your own, or create your own tools.

--- a/redfox/server.py
+++ b/redfox/server.py
@@ -1,0 +1,54 @@
+"""Development server support for redfox apps.
+
+WSGI applications in production should be served by a production-ready
+container such as gunicorn or mod_wsgi, but for development it's often
+convenient to be able to serve an app directly, without additional
+dependencies. This module wraps Werkzeug's ``run_simple`` function.
+
+Generally, apps that support a "development server" mode look something like
+
+    from redfox import WebApplication, get
+    from werkzeug import Response
+    
+    class MyApp(WebApplication):
+        @get('/')
+        def hello(request):
+            return Response("Hello, world!")
+    
+    if __name__ == '__main__':
+        from redfox import server
+        server.run(MyApp())
+
+"""
+
+from werkzeug import serving as ws
+
+def run(
+    application,
+    hostname='127.0.0.1',
+    port=9000,
+    debug=False,
+    **options
+):
+    """Serve ``application`` until interrupted. This is a wrapper around
+    ``werkzeug.serving.run_simple`` that provides some default values:
+    
+        * ``hostname`` defaults to ``'127.0.0.1'``.
+        * ``port`` defaults to ``9000``.
+    
+    Other parameters have their defaults as per Werkzeug's documentation, and
+    can be overridden by passing the corresponding keyword parameters to this
+    function.
+    
+    As a shortcut, you can pass ``debug=True`` to enable both the reloader and
+    the debugger feature. This parameter will not be passed through to
+    Werkzeug.
+    """
+    options.setdefault('use_reloader', debug)
+    options.setdefault('use_debugger', debug)
+    ws.run_simple(
+        hostname,
+        port,
+        application,
+        **options
+    )


### PR DESCRIPTION
For folks tinkering with the framework or with simple, low-load, low-contention applications, a simple single-threaded server is a useful place to start before switching to a real deployment option like mod_wsgi or Gunicorn. This change adds a `redfox.server` module that provides exactly that sort of tool, taking advantage of more of Werkzeug's features.